### PR TITLE
fix(upstream-renames): pre-apply 2026-05 ai settings rename/deletion (drains 2/8 of issue #27)

### DIFF
--- a/app/src/ai/agent/api.rs
+++ b/app/src/ai/agent/api.rs
@@ -240,7 +240,7 @@ impl RequestParams {
             user_workspaces.is_aws_bedrock_credentials_enabled(app),
         );
         let allow_use_of_warp_credits_with_byok =
-            *AISettings::as_ref(app).can_use_warp_credits_with_byok;
+            *AISettings::as_ref(app).can_use_warp_credits_for_fallback;
 
         let app_execution_mode = AppExecutionMode::as_ref(app);
         let autonomy_level = if app_execution_mode.is_autonomous() {

--- a/app/src/settings/ai.rs
+++ b/app/src/settings/ai.rs
@@ -1192,16 +1192,16 @@ define_settings_group!(AISettings, settings: [
         description: "Whether the \"What's new\" section is shown in the agent view.",
     }
 
-    // Whether or not the user has enabled the ability to use Warp credits even when providing
-    // their own LLM provider API key.
-    can_use_warp_credits_with_byok: CanUseWarpCreditsWithByok {
+    // Whether or not the user has enabled fallback to Warp credits for user-provided models.
+    can_use_warp_credits_for_fallback: CanUseWarpCreditsForFallback {
         type: bool,
         default: false,
         supported_platforms: SupportedPlatforms::ALL,
         sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
         private: false,
+        storage_key: "CanUseWarpCreditsWithByok",
         toml_path: "cloud_platform.third_party_api_keys.can_use_warp_credits_with_byok",
-        description: "Whether Warp credits can be used even when providing your own API key.",
+        description: "Whether Warp credits can be used as a fallback for user-provided models.",
     }
 
     should_render_use_agent_footer_for_user_commands: ShouldRenderUseAgentToolbarForUserCommands {
@@ -1355,21 +1355,6 @@ define_settings_group!(AISettings, settings: [
         private: false,
         toml_path: "agents.warp_agent.other.cloud_agent_computer_use_enabled",
         description: "Whether computer use is enabled for cloud agent conversations.",
-    }
-
-    // Whether multi-agent orchestration is enabled. When enabled, the agent can
-    // spawn and coordinate parallel sub-agents via StartAgent / SendMessageToAgent
-    // tools. This setting is only effective when FeatureFlag::Orchestration is also
-    // enabled.
-    orchestration_enabled: OrchestrationEnabled {
-        type: bool,
-        default: true,
-        supported_platforms: SupportedPlatforms::DESKTOP,
-        sync_to_cloud: SyncToCloud::Globally(RespectUserSyncSetting::Yes),
-        private: false,
-        toml_path: "agents.warp_agent.other.orchestration_enabled",
-        description: "Whether multi-agent orchestration is enabled.",
-        feature_flag: FeatureFlag::Orchestration,
     }
 
     // Whether file-based MCP servers from third-party AI tools (e.g. Claude, Codex) should
@@ -1637,9 +1622,7 @@ impl AISettings {
     }
 
     pub fn is_orchestration_enabled(&self, app: &warpui::AppContext) -> bool {
-        FeatureFlag::Orchestration.is_enabled()
-            && self.is_any_ai_enabled(app)
-            && *self.orchestration_enabled
+        FeatureFlag::OrchestrationV2.is_enabled() && self.is_any_ai_enabled(app)
     }
 
     /// Determines whether a quota reset banner should be displayed to the user.

--- a/app/src/settings_view/ai_page.rs
+++ b/app/src/settings_view/ai_page.rs
@@ -26,10 +26,10 @@ use crate::settings::{
     AIAutoDetectionEnabled, AICommandDenylist, AISettingsChangedEvent,
     AgentModeCodingPermissionsType, AgentModeCommandExecutionDenylist,
     AgentModeCommandExecutionPredicate, AgentModeQuerySuggestionsEnabled, AwsBedrockAutoLogin,
-    AwsBedrockCredentialsEnabled, CanUseWarpCreditsWithByok, CodeSettings, CodebaseContextEnabled,
-    FileBasedMcpEnabled, GitOperationsAutogenEnabled, IncludeAgentCommandsInHistory,
-    IntelligentAutosuggestionsEnabled, MemoryEnabled, NLDInTerminalEnabled,
-    NaturalLanguageAutosuggestionsEnabled, OrchestrationEnabled, RuleSuggestionsEnabled,
+    AwsBedrockCredentialsEnabled, CanUseWarpCreditsForFallback, CodeSettings,
+    CodebaseContextEnabled, FileBasedMcpEnabled, GitOperationsAutogenEnabled,
+    IncludeAgentCommandsInHistory, IntelligentAutosuggestionsEnabled, MemoryEnabled,
+    NLDInTerminalEnabled, NaturalLanguageAutosuggestionsEnabled, RuleSuggestionsEnabled,
     SharedBlockTitleGenerationEnabled, ShouldRenderCLIAgentToolbar,
     ShouldRenderUseAgentToolbarForUserCommands, ShouldShowOzUpdatesInZeroState, ShowAgentTips,
     ShowConversationHistory, ShowHintText, ThinkingDisplayMode, VoiceInputEnabled,
@@ -2241,7 +2241,7 @@ pub enum AISettingsPageAction {
     ToggleCLIAgentToolbar,
     ToggleUseAgentToolbar,
     ToggleVoiceInput,
-    ToggleCanUseWarpCreditsWithByok,
+    ToggleCanUseWarpCreditsForFallback,
     /// warp-cn fork: toggle the master Direct LLM backend switch.
     #[cfg(feature = "direct_llm_backend")]
     ToggleDirectLlmBackend,
@@ -2303,7 +2303,6 @@ pub enum AISettingsPageAction {
     ToggleAgentAttribution,
     #[cfg(feature = "local_fs")]
     SetConversationLayout(crate::util::file::external_editor::settings::OpenConversationPreference),
-    ToggleOrchestration,
     ToggleShowConversationHistory,
     ToggleAutoToggleRichInput,
     ToggleAutoOpenRichInputOnCLIAgentStart,
@@ -2644,10 +2643,10 @@ impl TypedActionView for AISettingsPageView {
                 }
                 ctx.notify();
             }
-            AISettingsPageAction::ToggleCanUseWarpCreditsWithByok => {
+            AISettingsPageAction::ToggleCanUseWarpCreditsForFallback => {
                 AISettings::handle(ctx).update(ctx, |settings, ctx| {
                     report_if_error!(settings
-                        .can_use_warp_credits_with_byok
+                        .can_use_warp_credits_for_fallback
                         .toggle_and_save_value(ctx));
                 });
                 ctx.notify();
@@ -3063,12 +3062,6 @@ impl TypedActionView for AISettingsPageView {
                     },
                     ctx
                 );
-                ctx.notify();
-            }
-            AISettingsPageAction::ToggleOrchestration => {
-                AISettings::handle(ctx).update(ctx, |settings, ctx| {
-                    report_if_error!(settings.orchestration_enabled.toggle_and_save_value(ctx));
-                });
                 ctx.notify();
             }
             AISettingsPageAction::ToggleShowConversationHistory => {
@@ -6253,7 +6246,6 @@ mod tests;
 #[derive(Default)]
 struct CloudAgentComputerUseWidget {
     toggle: SwitchStateHandle,
-    orchestration_toggle: SwitchStateHandle,
 }
 
 impl SettingsWidget for CloudAgentComputerUseWidget {
@@ -6265,7 +6257,7 @@ impl SettingsWidget for CloudAgentComputerUseWidget {
 
     fn render(
         &self,
-        view: &Self::View,
+        _view: &Self::View,
         appearance: &Appearance,
         app: &AppContext,
     ) -> Box<dyn Element> {
@@ -6329,7 +6321,7 @@ impl SettingsWidget for CloudAgentComputerUseWidget {
             None,
         );
 
-        let mut column = Flex::column()
+        Flex::column()
             .with_child(render_separator(appearance))
             .with_child(
                 build_sub_header(
@@ -6345,27 +6337,8 @@ impl SettingsWidget for CloudAgentComputerUseWidget {
                 warp_i18n::t!("settings-ai-cloud-computer-use-desc"),
                 !is_disabled,
                 app,
-            ));
-
-        if FeatureFlag::Orchestration.is_enabled() {
-            let ai_settings = AISettings::as_ref(app);
-            column.add_child(render_ai_setting_toggle::<OrchestrationEnabled>(
-                warp_i18n::t!("settings-ai-orchestration"),
-                AISettingsPageAction::ToggleOrchestration,
-                *ai_settings.orchestration_enabled,
-                is_any_ai_enabled,
-                self.orchestration_toggle.clone(),
-                &view.local_only_icon_tooltip_states,
-                app,
-            ));
-            column.add_child(render_ai_setting_description(
-                warp_i18n::t!("settings-ai-orchestration-desc"),
-                is_any_ai_enabled,
-                app,
-            ));
-        }
-
-        column.finish()
+            ))
+            .finish()
     }
 }
 
@@ -6385,7 +6358,7 @@ struct ApiKeysWidget {
     #[cfg(feature = "direct_llm_backend")]
     google_base_url_editor: ViewHandle<EditorView>,
 
-    can_use_warp_credits_with_byok: SwitchStateHandle,
+    can_use_warp_credits_for_fallback: SwitchStateHandle,
     upgrade_highlight_index: HighlightedHyperlink,
 }
 
@@ -6595,7 +6568,7 @@ impl ApiKeysWidget {
             #[cfg(feature = "direct_llm_backend")]
             google_base_url_editor,
 
-            can_use_warp_credits_with_byok: Default::default(),
+            can_use_warp_credits_for_fallback: Default::default(),
             upgrade_highlight_index: Default::default(),
         }
     }
@@ -6798,19 +6771,19 @@ impl ApiKeysWidget {
         column.finish()
     }
 
-    fn render_can_use_warp_credits_with_byok_toggle(
+    fn render_warp_credit_fallback_toggle(
         &self,
         view: &AISettingsPageView,
         app: &AppContext,
     ) -> Box<dyn Element> {
         let ai_settings = AISettings::as_ref(app);
 
-        let toggle = render_ai_setting_toggle::<CanUseWarpCreditsWithByok>(
+        let toggle = render_ai_setting_toggle::<CanUseWarpCreditsForFallback>(
             warp_i18n::t!("settings-ai-credit-fallback"),
-            AISettingsPageAction::ToggleCanUseWarpCreditsWithByok,
-            *ai_settings.can_use_warp_credits_with_byok,
+            AISettingsPageAction::ToggleCanUseWarpCreditsForFallback,
+            *ai_settings.can_use_warp_credits_for_fallback,
             ai_settings.is_any_ai_enabled(app),
-            self.can_use_warp_credits_with_byok.clone(),
+            self.can_use_warp_credits_for_fallback.clone(),
             &view.local_only_icon_tooltip_states,
             app,
         );
@@ -6860,7 +6833,7 @@ impl SettingsWidget for ApiKeysWidget {
 
         if is_byo_enabled {
             column.add_child(
-                Container::new(self.render_can_use_warp_credits_with_byok_toggle(view, app))
+                Container::new(self.render_warp_credit_fallback_toggle(view, app))
                     .with_margin_top(16.)
                     .finish(),
             );

--- a/app/src/terminal/input/slash_commands/data_source/mod.rs
+++ b/app/src/terminal/input/slash_commands/data_source/mod.rs
@@ -118,11 +118,7 @@ impl SlashCommandDataSource {
             _ => (),
         });
         ctx.subscribe_to_model(&AISettings::handle(ctx), |me, event, ctx| {
-            if matches!(
-                event,
-                AISettingsChangedEvent::IsAnyAIEnabled { .. }
-                    | AISettingsChangedEvent::OrchestrationEnabled { .. }
-            ) {
+            if matches!(event, AISettingsChangedEvent::IsAnyAIEnabled { .. }) {
                 me.recompute_active_commands(ctx);
             }
         });


### PR DESCRIPTION
## Summary

Pre-applies two upstream rename/deletion sets to shrink the conflict surface for the next weekly upstream sync. Drains **2 of 8** categories from #27 — the other **6 turned out to be merge artifacts**, not real fork bugs (see #27 update).

| # | Category | Source | Touched files |
|---|---|---|---|
| 1 | `CanUseWarpCreditsWithByok` → `CanUseWarpCreditsForFallback` | upstream #10892 | 3 |
| 2 | `OrchestrationEnabled` v1 setting removed | upstream #11035 | 3 |

## Cat 1 — Pure rename (zero user data risk)

`storage_key: "CanUseWarpCreditsWithByok"` is **added** to the renamed setting, so the existing TOML key is preserved. Users who already toggled the setting keep their preference across this rename.

Also matches upstream's function rename `render_can_use_warp_credits_with_byok_toggle` → `render_warp_credit_fallback_toggle` exactly, so this exact line will auto-merge at next sync.

## Cat 2 — Behavioral change (intentional, follows upstream)

Deletes the legacy v1 `orchestration_enabled` setting field and rewrites `AISettings::is_orchestration_enabled(app)` body:

```diff
 pub fn is_orchestration_enabled(&self, app: &warpui::AppContext) -> bool {
-    FeatureFlag::Orchestration.is_enabled()
-        && self.is_any_ai_enabled(app)
-        && *self.orchestration_enabled
+    FeatureFlag::OrchestrationV2.is_enabled() && self.is_any_ai_enabled(app)
 }
```

**Behavioral impact**: users who had explicitly toggled OFF the legacy "Orchestration" experimental setting will now get orchestration enabled when `FeatureFlag::OrchestrationV2` is on. Matches upstream PR #11035's intent (legacy v1 toggle deprecated in favor of v2 + global AI enablement).

The `pub orchestration_enabled: bool` field on `AgentApiCallParams` (api.rs:127) is a **different concept** — RPC tx struct, not the user setting — and is correctly preserved.

## Verification

```
WARPCN_SKIP_METAL=1 cargo check -p warp --lib
→ 21 pre-existing warnings (DirectProviderWidget dead_code etc.), 0 errors
```

## Diff size

```
 app/src/ai/agent/api.rs                            |  2 +-
 app/src/settings/ai.rs                             | 27 ++-------
 app/src/settings_view/ai_page.rs                   | 65 +++++++---------------
 .../input/slash_commands/data_source/mod.rs        |  6 +-
 4 files changed, 26 insertions(+), 74 deletions(-)
```

## Why now, not at sync time

The previous sync attempt (2026-05-21) hit ~197 cascading errors **after** auto-merge from these exact renames. Pre-applying them to master collapses ~14 of those errors and removes the rename surface from the next sync's merge conflict set.

Refs: #27