### PR TITLE
fix: 将 macOS 专属链接参数限定到 macOS 目标(修复 Windows/Linux 构建)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,10 +12,18 @@ xtask = "run --package xtask --bin xtask --"
 MACOSX_DEPLOYMENT_TARGET = "10.14"
 
 [build]
-rustflags = ["-C", "symbol-mangling-version=v0", "-C", "link-args=-Wl,-headerpad_max_install_names"]
+rustflags = ["-C", "symbol-mangling-version=v0"]
 
 [net]
 git-fetch-with-cli = true
+
+[target.'cfg(target_os = "macos")']
+# `-headerpad_max_install_names` is a macOS/Mach-O linker flag (it reserves space
+# in the Mach-O header for `install_name_tool` to rewrite dylib install names
+# during bundling, see `script/bundle`). It is passed via the GNU-style `-Wl,`
+# driver syntax and is rejected by Windows (MSVC `link.exe` / `lld-link`) and by
+# the Linux linker, so it must only be applied on macOS.
+rustflags = ["-C", "link-args=-Wl,-headerpad_max_install_names"]
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -23,7 +23,7 @@ git-fetch-with-cli = true
 # during bundling, see `script/bundle`). It is passed via the GNU-style `-Wl,`
 # driver syntax and is rejected by Windows (MSVC `link.exe` / `lld-link`) and by
 # the Linux linker, so it must only be applied on macOS.
-rustflags = ["-C", "link-args=-Wl,-headerpad_max_install_names"]
+rustflags = ["-C", "symbol-mangling-version=v0", "-C", "link-args=-Wl,-headerpad_max_install_names"]
 
 [target.'cfg(target_family = "wasm")']
 rustflags = ["--cfg=web_sys_unstable_apis"]


### PR DESCRIPTION
## 背景

为 #10(Windows 安装包)做准备:在 Windows 上原生构建 `warp-oss` 时,链接阶段直接失败。同样的问题也影响 Linux 原生构建。

## 根因

`.cargo/config.toml` 的 `[build] rustflags` 含 macOS 专属链接参数 `-Wl,-headerpad_max_install_names`。它是 Mach-O 的 `install_name` 概念,通过 GNU 风格 `-Wl,` 透传给链接器。Windows(MSVC `link.exe` / `lld-link`)与 Linux 链接器都不认这个参数:

```
link: unknown option -- W
```

## 修复

把该参数移入 `[target.'cfg(target_os = "macos")']`,`[build]` 段仅保留跨平台的 `symbol-mangling-version=v0`。

- **macOS**:行为不变(`script/bundle` 仍用 `install_name_tool` 改写 dylib install name)
- **Windows / Linux**:不再注入该参数,链接通过

## 验证

应用本修复后,配合便携 MSVC 工具链(xwin + LLVM)运行 `cargo build --bin warp-oss`,成功产出 `target/debug/warp-oss.exe`(PE32+ x86-64),退出码 0。