### PR TITLE
docs(windows): 精确化 README 资源编译描述（cl.exe vs rc.exe）

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ resources\                ← 打包资源（由安装流程生成）
 
 ### 从源码构建
 
-在 Windows 上构建需要 MSVC 工具链（Visual Studio 2022 Build Tools，含 Windows SDK），`app/build.rs` 经注册表定位 `RC.EXE` 编译资源：
+在 Windows 上构建需要 MSVC 工具链（Visual Studio 2022 Build Tools，含 Windows SDK）。`app/build.rs` 经注册表定位 `cl.exe` 以装配 MSVC 环境（让资源编译器能找到头文件），再由 embed-resource 调用 `rc.exe` 编译资源：
 
 ```sh
 cargo build --release --bin warp-oss --features gui

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,7 +75,7 @@ resources\                ← 打包资源（由安装流程生成）
 
 ### 从源码构建
 
-在 Windows 上构建需要 MSVC 工具链（Visual Studio 2022 Build Tools，含 Windows SDK）。`app/build.rs` 经注册表定位 `cl.exe` 以装配 MSVC 环境（让资源编译器能找到头文件），再由 embed-resource 调用 `rc.exe` 编译资源：
+在 Windows 上构建有两条资源编译路径。默认（未设置 `WARP_RC` 时）需要 MSVC 工具链（Visual Studio 2022 Build Tools，含 Windows SDK）：`app/build.rs` 经注册表定位 `cl.exe` 以装配 MSVC 环境（让资源编译器能找到头文件），再由 embed-resource 调用 `rc.exe` 编译资源：
 
 ```sh
 cargo build --release --bin warp-oss --features gui
@@ -83,7 +83,7 @@ cargo build --release --bin warp-oss --features gui
 
 还需 `protoc`（protobuf 编译器）在 PATH 上。
 
-> **免 Visual Studio 的便携工具链**（LLVM `clang-cl` / `lld-link` / `llvm-rc` + xwin，通过 `WARP_RC` 环境变量指定独立资源编译器）尚未合入 master，相关支持见 PR #31；合并后详细配置见 `docs/building-windows-portable.md`。
+> **免 Visual Studio 的便携工具链**（LLVM `clang-cl` / `lld-link` / `llvm-rc` + xwin）已支持：设置 `WARP_RC` 环境变量指向独立资源编译器（如 `llvm-rc`）后，`app/build.rs` 会直接用它编译资源、跳过上面的 `cl.exe` 注册表查找。详细配置见 [`docs/building-windows-portable.md`](docs/building-windows-portable.md)。
 
 ### 中文渲染
 


### PR DESCRIPTION
## 背景

@Heartcoolman 在 #34 review 里指出一处非阻塞 nit：README_zh.md 「从源码构建」段落写「`app/build.rs` 经注册表定位 `RC.EXE` 编译资源」措辞不准确。

## 核实

对照 `app/build.rs` 源码确认：

- `build.rs:719` — `cc::windows_registry::find_tool(target, "cl.exe")` 经注册表定位的是 **cl.exe**，用于装配 MSVC 环境变量（让资源编译器找到头文件）
- `build.rs:716` 注释原文：`Obtain MSVC environment so that the rc compiler can find the right headers`
- `build.rs:724` — 随后由 `embed_resource::compile(...)` 调用 `rc.exe` 编译资源

即「定位 cl.exe 设 MSVC 环境 → embed-resource 调 rc.exe」两步，原文把它说成「定位 RC.EXE」混淆了这两者。

## 改动

仅一行措辞修正，不涉及任何代码或行为变更。

> 在 Windows 上构建需要 MSVC 工具链（Visual Studio 2022 Build Tools，含 Windows SDK）。`app/build.rs` 经注册表定位 `cl.exe` 以装配 MSVC 环境（让资源编译器能找到头文件），再由 embed-resource 调用 `rc.exe` 编译资源：

回应 #34 review nit。
