### PR TITLE
fix(i18n): remove duplicate key in settings_billing.ftl (resolves #39)

### DIFF
--- a/crates/warp_i18n/bundles/en/settings_billing.ftl
+++ b/crates/warp_i18n/bundles/en/settings_billing.ftl
@@ -128,5 +128,4 @@ settings-billing-upgrade-enterprise = Upgrade to Enterprise
 settings-billing-enterprise-suffix = " for custom limits and dedicated support."
 settings-billing-contact-support-suffix = " for more AI usage."
 settings-billing-build-byok-credits-suffix = " for more credits and access to more models."
-settings-billing-no-usage-history = No usage history
 settings-billing-usage-history-empty-hint = Kick off an agent task to view usage history here.

--- a/crates/warp_i18n/bundles/zh-CN/settings_billing.ftl
+++ b/crates/warp_i18n/bundles/zh-CN/settings_billing.ftl
@@ -128,5 +128,4 @@ settings-billing-upgrade-enterprise = 升级到 Enterprise
 settings-billing-enterprise-suffix = " 以获取定制限额与专属支持。"
 settings-billing-contact-support-suffix = " 以获取更多 AI 用量。"
 settings-billing-build-byok-credits-suffix = " 以获得更多额度和更多模型。"
-settings-billing-no-usage-history = 暂无用量历史
 settings-billing-usage-history-empty-hint = 启动一个智能体任务后，即可在此查看用量历史。


### PR DESCRIPTION
Resolves #39 — duplicate key 'settings-billing-no-usage-history' at line 131 causes fluent_syntax to fail during warp_i18n::init(), rendering all UI strings as {key} placeholders.

Removed duplicate entry from:
- crates/warp_i18n/bundles/en/settings_billing.ftl
- crates/warp_i18n/bundles/zh-CN/settings_billing.ftl

The key correctly appears once at line 5 in both files.