### PR TITLE
fix(i18n): remove duplicate ftl key + add duplicate-key guards (resolves #39, #44, #46)

### DIFF
--- a/crates/warp_i18n/build.rs
+++ b/crates/warp_i18n/build.rs
@@ -6,7 +6,7 @@
 //!   in `bundles/en/`. Downstream code may `include!` it for runtime sanity checks.
 //! - Re-run when bundle contents change.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -19,6 +19,15 @@ fn main() {
 
     let mut en_keys: BTreeSet<String> = BTreeSet::new();
     let mut errors: Vec<String> = Vec::new();
+    // Per-locale message-id occurrences across ALL files of that locale.
+    // `load_locale` (loader.rs) merges every `<locale>/*.ftl` into one
+    // `FluentBundle`, and `add_resource` rejects any id already present —
+    // within OR across files — with an `Overriding` error. That error aborts
+    // `warp_i18n::init`, leaving the global unset so every `t!()` renders as
+    // `{key}` (lib.rs:107-110). The syntactic `parse` below does NOT catch
+    // duplicate ids, so detect them here and fail the build, mirroring exactly
+    // what `add_resource` would reject at runtime.
+    let mut occurrences: BTreeMap<String, BTreeMap<String, Vec<String>>> = BTreeMap::new();
 
     for entry in walkdir::WalkDir::new(&bundles_dir).into_iter().flatten() {
         if !entry.file_type().is_file() {
@@ -35,12 +44,23 @@ fn main() {
                 continue;
             }
         };
+        let rel = entry
+            .path()
+            .strip_prefix(&bundles_dir)
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| entry.path().display().to_string());
         match fluent_syntax::parser::parse(source.as_str()) {
             Ok(resource) => {
-                if is_en(entry.path(), &bundles_dir) {
-                    for entry in resource.body {
-                        if let fluent_syntax::ast::Entry::Message(msg) = entry {
-                            en_keys.insert(msg.id.name.to_string());
+                if let Some(locale) = locale_of(entry.path(), &bundles_dir) {
+                    let is_en = locale == "en";
+                    let per_key = occurrences.entry(locale).or_default();
+                    for item in &resource.body {
+                        if let fluent_syntax::ast::Entry::Message(msg) = item {
+                            let name = msg.id.name.to_string();
+                            if is_en {
+                                en_keys.insert(name.clone());
+                            }
+                            per_key.entry(name).or_default().push(rel.clone());
                         }
                     }
                 }
@@ -53,11 +73,31 @@ fn main() {
         }
     }
 
+    for (locale, keys) in &occurrences {
+        for (key, files) in keys {
+            if files.len() > 1 {
+                let mut unique: Vec<&String> = files.iter().collect();
+                unique.dedup();
+                errors.push(format!(
+                    "duplicate key '{key}' in locale '{locale}' ({} occurrences in {}); \
+                     FluentBundle::add_resource rejects this and warp_i18n::init() then \
+                     fails, rendering every UI string as {{key}}",
+                    files.len(),
+                    unique
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+        }
+    }
+
     if !errors.is_empty() {
         for e in &errors {
             eprintln!("warp_i18n: ftl error: {e}");
         }
-        panic!("warp_i18n: {} ftl parse error(s); aborting build", errors.len());
+        panic!("warp_i18n: {} ftl error(s); aborting build", errors.len());
     }
 
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -130,10 +170,12 @@ fn main() {
     writeln!(file, "];").unwrap();
 }
 
-fn is_en(path: &Path, bundles_dir: &Path) -> bool {
+/// Locale directory a bundle file lives in (the first path component under
+/// `bundles/`), e.g. `en` or `zh-CN`. Returns `None` for files placed directly
+/// in `bundles/`.
+fn locale_of(path: &Path, bundles_dir: &Path) -> Option<String> {
     path.strip_prefix(bundles_dir)
         .ok()
         .and_then(|p| p.components().next())
-        .map(|c| c.as_os_str() == "en")
-        .unwrap_or(false)
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
 }

--- a/crates/warp_i18n/bundles/en/settings_billing.ftl
+++ b/crates/warp_i18n/bundles/en/settings_billing.ftl
@@ -128,5 +128,4 @@ settings-billing-upgrade-enterprise = Upgrade to Enterprise
 settings-billing-enterprise-suffix = " for custom limits and dedicated support."
 settings-billing-contact-support-suffix = " for more AI usage."
 settings-billing-build-byok-credits-suffix = " for more credits and access to more models."
-settings-billing-no-usage-history = No usage history
 settings-billing-usage-history-empty-hint = Kick off an agent task to view usage history here.

--- a/crates/warp_i18n/bundles/zh-CN/settings_billing.ftl
+++ b/crates/warp_i18n/bundles/zh-CN/settings_billing.ftl
@@ -128,5 +128,4 @@ settings-billing-upgrade-enterprise = 升级到 Enterprise
 settings-billing-enterprise-suffix = " 以获取定制限额与专属支持。"
 settings-billing-contact-support-suffix = " 以获取更多 AI 用量。"
 settings-billing-build-byok-credits-suffix = " 以获得更多额度和更多模型。"
-settings-billing-no-usage-history = 暂无用量历史
 settings-billing-usage-history-empty-hint = 启动一个智能体任务后，即可在此查看用量历史。

--- a/crates/warp_i18n/src/lib_tests.rs
+++ b/crates/warp_i18n/src/lib_tests.rs
@@ -118,6 +118,15 @@ fn plural_selector_en_one_vs_other() {
 }
 
 #[test]
+fn production_bundles_load_without_errors() {
+    // Regression guard for #39/#44: a duplicate key in any bundle file makes
+    // `FluentBundle::add_resource` fail, so `Bundles::load` (and thus
+    // `warp_i18n::init`) returns Err and every UI string renders as `{key}`.
+    // Loading the real embedded en/zh-CN bundles must always succeed.
+    crate::loader::Bundles::load().expect("production bundles must load");
+}
+
+#[test]
 fn init_is_idempotent() {
     ensure_init();
     let _g = lock().lock();

--- a/xtask/src/i18n_lint/parity.rs
+++ b/xtask/src/i18n_lint/parity.rs
@@ -15,19 +15,37 @@ pub struct Mismatch {
 pub enum MismatchKind {
     MissingInZh,
     MissingInEn,
+    /// Same message id defined more than once within a locale (across its
+    /// `.ftl` files). `load_locale` merges every `<locale>/*.ftl` into one
+    /// `FluentBundle`; `add_resource` rejects the duplicate, so
+    /// `warp_i18n::init` fails and every UI string renders as `{key}` (#39/#44).
+    Duplicate { locale: String, files: Vec<String> },
 }
 
 impl fmt::Display for Mismatch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let side = match self.kind {
-            MismatchKind::MissingInZh => "missing in zh-CN",
-            MismatchKind::MissingInEn => "missing in en",
-        };
-        write!(f, "parity: {} key {:?} {side}", self.bundle, self.key)
+        match &self.kind {
+            MismatchKind::MissingInZh => {
+                write!(f, "parity: {} key {:?} missing in zh-CN", self.bundle, self.key)
+            }
+            MismatchKind::MissingInEn => {
+                write!(f, "parity: {} key {:?} missing in en", self.bundle, self.key)
+            }
+            MismatchKind::Duplicate { locale, files } => write!(
+                f,
+                "duplicate: key {:?} defined {} times in locale {} ({}) — \
+                 breaks warp_i18n::init() at runtime, all UI renders as {{key}}",
+                self.key,
+                files.len(),
+                locale,
+                files.join(", "),
+            ),
+        }
     }
 }
 
-/// Compare en/zh-CN bundles file-by-file. Returns the union of missing keys.
+/// Compare en/zh-CN bundles file-by-file and flag duplicate keys within each
+/// locale. Returns the union of missing keys plus any duplicates.
 pub fn check(bundles_root: &Path) -> Result<Vec<Mismatch>> {
     let en = collect(&bundles_root.join("en"))?;
     let zh = collect(&bundles_root.join("zh-CN"))?;
@@ -53,7 +71,53 @@ pub fn check(bundles_root: &Path) -> Result<Vec<Mismatch>> {
             });
         }
     }
+
+    mismatches.extend(duplicates(&bundles_root.join("en"), "en")?);
+    mismatches.extend(duplicates(&bundles_root.join("zh-CN"), "zh-CN")?);
     Ok(mismatches)
+}
+
+/// Flag any message id defined more than once across a locale's `.ftl` files
+/// (including twice in the same file). Mirrors `FluentBundle::add_resource`'s
+/// duplicate-id rejection so the failure surfaces at lint time, not as a
+/// runtime `{key}` blowup (#39/#44).
+fn duplicates(dir: &Path, locale: &str) -> Result<Vec<Mismatch>> {
+    let mut counts: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    if dir.exists() {
+        for entry in WalkDir::new(dir).into_iter().filter_map(Result::ok) {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.into_path();
+            if path.extension().and_then(|s| s.to_str()) != Some("ftl") {
+                continue;
+            }
+            let name = path
+                .strip_prefix(dir)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let text = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {}", path.display()))?;
+            for key in parse_keys_list(&text) {
+                counts.entry(key).or_default().push(name.clone());
+            }
+        }
+    }
+    let mut out = Vec::new();
+    for (key, files) in counts {
+        if files.len() > 1 {
+            out.push(Mismatch {
+                bundle: locale.to_string(),
+                key,
+                kind: MismatchKind::Duplicate {
+                    locale: locale.to_string(),
+                    files,
+                },
+            });
+        }
+    }
+    Ok(out)
 }
 
 fn collect(dir: &Path) -> Result<BTreeMap<String, BTreeSet<String>>> {
@@ -83,9 +147,15 @@ fn collect(dir: &Path) -> Result<BTreeMap<String, BTreeSet<String>>> {
 
 /// Minimal Fluent key extractor: a key starts at the beginning of a line and
 /// matches `[A-Za-z][A-Za-z0-9_-]*` followed by ` =`. Comments (`#`) and
-/// continuation lines are ignored.
+/// continuation lines are ignored. Deduplicates within a file.
 fn parse_keys(text: &str) -> BTreeSet<String> {
-    let mut keys = BTreeSet::new();
+    parse_keys_list(text).into_iter().collect()
+}
+
+/// Like [`parse_keys`] but preserves every occurrence in source order so callers
+/// can detect keys defined more than once within a single file.
+fn parse_keys_list(text: &str) -> Vec<String> {
+    let mut keys = Vec::new();
     for line in text.lines() {
         if line.starts_with('#') || line.starts_with(' ') || line.starts_with('\t') {
             continue;
@@ -108,7 +178,7 @@ fn parse_keys(text: &str) -> BTreeSet<String> {
         if !chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
             continue;
         }
-        keys.insert(head.to_string());
+        keys.push(head.to_string());
     }
     keys
 }


### PR DESCRIPTION
## 问题（#39 / #44 / #46 同一根因）

`crates/warp_i18n/bundles/{en,zh-CN}/settings_billing.ftl` 第 5 行与第 131 行重复定义 `settings-billing-no-usage-history`。同一 locale 的所有 `.ftl` 会合并进同一个 `FluentBundle`，`add_resource` 对重复 message id 返回 `Overriding` 错误 → `Bundles::load()` 失败 → `warp_i18n::init()` 失败 → 全局 `I18N` 永不初始化 → 之后每次 `render()` 走 `try_global() == None` 分支返回 `format!("{{{key}}}")`，**整个 UI 崩成 `{key}` 占位符**。

已发布 tag `v0.2026.06.01-cn.0` 经 `git show` 确认仍含该重复，故 macOS 与 **Windows** 两个产物都被击穿。`warp_i18n` 是无条件依赖、bundle 由 `build.rs` `include_str!` 无平台门控嵌入、`script/windows/bundle.ps1` 编译同一个 `warp-oss`——不存在"只给 Windows 英文"的代码路径，因此 **#46 是同一 release 的 i18n 崩坏在 Windows 上的表现，修本 PR 即修 #46**。

### 为何漏过 CI
- `build.rs` 只做 `fluent_syntax::parser::parse`（纯语法），不检测重复 id；
- `xtask check-i18n --check-parity` 的 `parse_keys` 用 `BTreeSet`，**静默吞掉**重复；
- 仓库没有运行 `cargo test` 的 workflow（现有单测能抓却从不跑）。

## 改动

1. **删除两文件第 131 行重复项**；第 5 行保留 `no-usage-history`，第 132 行保留代码引用的 `usage-history-empty-hint`。
2. **`build.rs`**：按 locale 跨所有 `.ftl` 累计 message id，重复则 `panic!` 中止构建——镜像 `add_resource` 的 `Overriding` 语义，**从源头阻止损坏二进制发包**。
3. **`xtask/src/i18n_lint/parity.rs`**：新增 `MismatchKind::Duplicate` 检测 + `parse_keys_list`，`check()` 对 en/zh-CN 跨文件去重（`i18n-lint.yml` 的 PR 闸门）。
4. **`crates/warp_i18n/src/lib_tests.rs`**：回归单测 `production_bundles_load_without_errors` 断言 `Bundles::load().is_ok()`。

## 验证

- `cargo build -p warp_i18n` ✅、`cargo xtask check-i18n --check-parity` → `bundle parity OK` ✅、`cargo test -p warp_i18n` ✅
- **负向测试**：注入一条重复 key → `xtask parity` 报 `duplicate: key ...`、`build.rs` `aborting build` **均正确拦截**；还原后全绿。

> 合并后需按惯例打新 tag 触发 release，修复才会到用户手中。

Supersedes #45（仅一行删除、无防护守卫；本 PR 为其超集）。