### PR TITLE
ci(linux): install cargo-about (fixes Linux build license-gen failure)

### DIFF
--- a/.github/workflows/build-linux-app.yml
+++ b/.github/workflows/build-linux-app.yml
@@ -105,6 +105,12 @@ jobs:
           # bundle_appimage 通过 PATH 调用 linuxdeploy；脚本把它装到 ~/.local/bin。
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      - name: Install cargo-about (license generation)
+        # bundle_appimage → script/prepare_bundled_resources 会跑 `cargo about generate`
+        # 生成 THIRD_PARTY_LICENSES.txt，缺该子命令则打包步骤必失败
+        # （error: no such command: `about`）。版本与 windows/mac workflow 保持一致。
+        run: cargo install --locked cargo-about@0.8.4
+
       - name: Build & bundle
         id: bundle
         run: |


### PR DESCRIPTION
首次 Linux 构建（v0.2026.06.01-cn.1）编译成功但在打包阶段失败：`script/prepare_bundled_resources` 跑 `cargo about generate` 生成 THIRD_PARTY_LICENSES.txt，而 `cargo-about` 未安装（`error: no such command: about`）。Windows workflow 已装它，这里同样补上 `cargo-about@0.8.4`。

后续：合并后用 workflow_dispatch 跑一次 release-profile Linux 构建，把产物挂到 v0.2026.06.01-cn.1。