### PR TITLE
fix(linux/rpm): sanitize version so .rpm packaging succeeds

### DIFF
--- a/script/linux/bundle_rpm
+++ b/script/linux/bundle_rpm
@@ -66,7 +66,11 @@ rm -rf "$RPMBUILD_DIR"
 mkdir -p "$RPMBUILD_DIR"/{SPEC,RPMS}
 
 # Move the RPM-specific package metadata into the package directory.
-VERSION="$GIT_RELEASE_TAG"
+# RPM's Version field forbids '-' (it separates version from release), so strip
+# the leading 'v' and replace any '-' with '.'. Without this, fork tags like
+# 'v0.2026.06.01-cn.1' make rpmbuild fail with
+# "Illegal char '-' (0x2d) in: Version:". (bundle_deb sanitizes similarly.)
+VERSION="$(echo "$GIT_RELEASE_TAG" | sed -E 's/^v//; s/-/./g')"
 RELEASE="1"
 sed \
     "s#@@CHANNEL_SUFFIX@@#$CHANNEL_SUFFIX#g; \
@@ -92,8 +96,10 @@ cp "$RPMBUILD_DIR/RPMS/$ARCH/$RPM_NAME" "$OUT_DIR"
 # should have already been added to the gpg-agent with a preset passphrase.
 if [ "${GITHUB_ACTIONS}" == "true" ]; then
   # Import our signing key's public key into rpm so the signature can be
-  # verified.
-  sudo rpm --import https://releases.warp.dev/linux/keys/warp.asc
+  # verified. Non-fatal: it's only needed for downstream signature verification,
+  # not for producing the package, and the OSS fork doesn't sign anyway (the
+  # rpmsign below is already `|| true`).
+  sudo rpm --import https://releases.warp.dev/linux/keys/warp.asc || true
 
   # We use batch mode with tty-based pin entry to ensure that the build doesn't
   # hang waiting on user input if, for some reason, we failed to preset the


### PR DESCRIPTION
首个 Linux 构建里 AppImage 和 .deb 都成功，仅 .rpm 失败：`error: Illegal char '-' (0x2d) in: Version: v0.2026.06.01-cn.1`。RPM 的 Version 字段不允许 `-`。

修复：像 `bundle_deb` 一样清洗版本——去掉前缀 `v`、把 `-` 换成 `.`，得到 `0.2026.06.01.cn.1`。另把 `sudo rpm --import`（仅用于验签）改为非致命 `|| true`。

合并后用 workflow_dispatch（release_tag=v0.2026.06.01-cn.1）重新构建，把 AppImage/.deb/.rpm 补到该 release。